### PR TITLE
Fix build when directory not equals name

### DIFF
--- a/rpm/harbour-sailtuner.spec
+++ b/rpm/harbour-sailtuner.spec
@@ -40,7 +40,7 @@ Instrumental multi-temperament chromatic tuner
 # >> build pre
 # << build pre
 
-%qtc_qmake5 
+%qtc_qmake5 %{name}.pro
 
 %qtc_make %{?_smp_mflags}
 


### PR DESCRIPTION
Just a lttle fix to an otherwise soundly working tool.